### PR TITLE
fix: Add comprehensive virtual environment patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,16 @@ target/
 # pyenv
 .python-version
 
+# Virtual environments
+env/
+venv/
+.venv/
+.env/
+ENV/
+env.bak/
+venv.bak/
+.virtualenv/
+
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies


### PR DESCRIPTION
## Problem
The current .gitignore was missing common virtual environment directory patterns, causing .venv/ to show up as untracked in git status.

## Solution
Added comprehensive virtual environment patterns including:
- `env/`, `venv/`, `.venv/`, `.env/`, `ENV/`
- `env.bak/`, `venv.bak/`, `.virtualenv/`

## Testing
- ✅ Verified .venv/ is now properly ignored
- ✅ Tested with `git check-ignore` to confirm all patterns work
- ✅ No breaking changes to existing functionality

## Impact
- Prevents accidental commit of virtual environment directories
- Covers all standard Python virtual environment naming conventions
- Improves developer experience across different environment setups

## Changes
```diff
+# Virtual environments
+env/
+venv/
+.venv/
+.env/
+ENV/
+env.bak/
+venv.bak/
+.virtualenv/
```