### PR TITLE
docs: Enforce strict branch protection for all users

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,3 +371,4 @@ If you use solo-learn, please cite our [paper](https://jmlr.org/papers/v23/21-11
   url     = {http://jmlr.org/papers/v23/21-1155.html}
 }
 ```
+

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ If you want to contribute to solo-learn, make sure you take a look at [how to co
 This repository uses branch protection rules to maintain code quality and require peer review:
 
 ### Branch Protection Rules
-- **Main branch is protected**: Direct pushes to `main` are blocked for regular contributors
+- **Main branch is strictly protected**: Direct pushes to `main` are blocked for **everyone** (including owners)
 - **Pull Request required**: All changes must go through a Pull Request with at least 1 approval
 - **Linear history enforced**: No merge commits allowed (rebase or squash-merge only)
 - **Conversations must be resolved**: All review comments must be addressed before merging
@@ -221,19 +221,8 @@ This repository uses branch protection rules to maintain code quality and requir
 6. **Merge**: Use "Squash and merge" or "Rebase and merge" to maintain linear history
 
 ### Workflow for Owners/Admins
-Owners and admins have additional privileges and can choose between two workflows:
+**All changes must go through Pull Requests** - no exceptions for normal development:
 
-**Option 1: Direct Push (Bypasses Protection)**
-```bash
-git checkout main
-git pull origin main
-# Make changes
-git add .
-git commit -m "Your commit message"
-git push origin main  # This will bypass branch protection rules
-```
-
-**Option 2: Standard PR Workflow (Recommended)**
 ```bash
 git checkout -b feature/your-feature
 # Make changes
@@ -241,7 +230,15 @@ git push origin feature/your-feature
 gh pr create  # Create and merge through PR process
 ```
 
-**Note**: Even when owners push directly to main, GitHub shows "Bypassed rule violations" to maintain transparency. The PR workflow is still recommended for complex changes to benefit from peer review.
+### Emergency Access for Owners
+For critical emergencies only, owners can temporarily disable branch protection:
+
+1. **Disable protection**: Go to Settings > Branches > Edit main branch protection
+2. **Make emergency changes**: Push directly to main
+3. **Re-enable protection**: Restore the protection rules immediately
+4. **Document the emergency**: Create an issue explaining why emergency access was used
+
+**Note**: This ensures a clear audit trail and separation between normal development and emergency procedures.
 
 ### Environment Setup
 1. **Python Environment**: Create a virtual environment: `python -m venv .venv && source .venv/bin/activate`

--- a/README.md
+++ b/README.md
@@ -221,8 +221,9 @@ This repository uses branch protection rules to maintain code quality and requir
 6. **Merge**: Use "Squash and merge" or "Rebase and merge" to maintain linear history
 
 ### Workflow for Owners/Admins
-**All changes must go through Pull Requests** - no exceptions for normal development:
+- **All changes must go through Pull Requests** - no exceptions for normal development
 
+**Standard PR workflow:**
 ```bash
 git checkout -b feature/your-feature
 # Make changes

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ This repository uses branch protection rules to maintain code quality and requir
 5. **Get review and approval**: At least 1 team member must approve
 6. **Merge**: Use "Squash and merge" or "Rebase and merge" to maintain linear history
 
-### Workflow for Owners/Admins
+### Standard PR Workflow
 - **All changes must go through Pull Requests** - no exceptions for normal development
 
 **Standard PR workflow:**


### PR DESCRIPTION
## Summary
Updated branch protection to enforce rules for all users including owners/admins.

## Changes
- Set `enforce_admins: true` in branch protection rules
- Updated README.md Contributing section to reflect strict PR-only workflow
- Documented emergency access procedure for critical situations
- Removed outdated information about owner bypass capabilities

## Why This Change
This provides better security when granting access to automated agents while maintaining a clear separation between normal development workflow and emergency procedures.

## Testing
✅ Confirmed direct pushes to main are now blocked for owners
✅ Feature branch pushes work normally  
✅ Emergency access procedure documented for critical situations